### PR TITLE
[release-v0.15.0] Upgrade to Go 1.24.5 to fix CVE-2025-22874

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.2
+go 1.24.5
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
| Severity | Image                 | CVE            | Package | Fix              | 
|----------|----------------------|----------------|---------|------------------|
| HIGH     | kube-rbac-proxy:v0.15.0-t | CVE-2025-22874 | stdlib  | v1.24.2 → 1.24.4 |
