### PR TITLE
[release-v0.15.0] Upgrade to Go 1.24.6 to fix CVE-2025-47907

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
required to fix high cve: [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907)