### PR TITLE
[release-v0.15.0] Upgrade to Go 1.24.9 to fix several CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Bump go to latest `1.24.9` to fix:

- CVE-2025-58186
- CVE-2025-58187
- CVE-2025-58188
- CVE-2025-58189
- CVE-2025-61723
- CVE-2025-61724
- CVE-2025-61725