### PR TITLE
cves: bump Go to 1.24.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Fixes:
- CVE-2025-61728
- CVE-2025-61726
