### PR TITLE
cves: bump go to 1.26.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: docker.io/tetrate/kube-rbac-proxy
-  go-version: '1.25.9'
+  go-version: '1.26.3'
   kind-version: 'v0.20.0'
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Summary

Bump Go version from 1.25.9 to 1.26.3.

## Changes

- Updated `go` directive to `1.26.3` in `go.mod`
- Ran `go mod tidy`
- Updated `go-version` env var in `.github/workflows/build.yml` to `1.26.3`