### PR TITLE
cves: bump go to 1.25.10 to fix stdlib CVEs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: docker.io/tetrate/kube-rbac-proxy
-  go-version: '1.25.9'
+  go-version: '1.25.10'
   kind-version: 'v0.20.0'
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| High | CVE-2026-39825 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-39836 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-42499 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-33811 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-39826 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-39820 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-33814 | stdlib | Bumped Go 1.25.9 → 1.25.10 |
| High | CVE-2026-39823 | stdlib | Bumped Go 1.25.9 → 1.25.10 |

## Summary

Bumps the Go toolchain from 1.25.9 to 1.25.10 in `go.mod` and `.github/workflows/build.yml` to address 8 stdlib CVEs present in the current image (`kube-rbac-proxy:v0.15.0-tetrate-v17`).

The same image tag is shared across all monorepo branches (master, release-1.11.x, release-1.12.x, release-1.14.x), so this single fix covers all branches.

Related to tetrateio/tetrate#30114
Related to tetrateio/tetrate#30115
Related to tetrateio/tetrate#30116
Related to tetrateio/tetrate#30117
Related to tetrateio/tetrate#30118
Related to tetrateio/tetrate#30119
Related to tetrateio/tetrate#30120
Related to tetrateio/tetrate#30121
Related to tetrateio/tetrate#30122
Related to tetrateio/tetrate#30123
Related to tetrateio/tetrate#30126
Related to tetrateio/tetrate#30127
Related to tetrateio/tetrate#30128
Related to tetrateio/tetrate#30129
Related to tetrateio/tetrate#30130
Related to tetrateio/tetrate#30131
Related to tetrateio/tetrate#30132
Related to tetrateio/tetrate#30133
Related to tetrateio/tetrate#30134
Related to tetrateio/tetrate#30135
Related to tetrateio/tetrate#30136
Related to tetrateio/tetrate#30137
Related to tetrateio/tetrate#30138
Related to tetrateio/tetrate#30139
Related to tetrateio/tetrate#30142
Related to tetrateio/tetrate#30143
Related to tetrateio/tetrate#30144
Related to tetrateio/tetrate#30145
Related to tetrateio/tetrate#30146
Related to tetrateio/tetrate#30147
Related to tetrateio/tetrate#30148
Related to tetrateio/tetrate#30149