### PR TITLE
cves: bump go to 1.26.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   QUAY_PATH: docker.io/tetrate/kube-rbac-proxy
-  go-version: '1.26.3'
+  go-version: '1.26.4'
   kind-version: 'v0.20.0'
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## CVEs addressed

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| UNKNOWN | CVE-2026-42504 | stdlib | bumped Go 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-27145 | stdlib | bumped Go 1.26.3 → 1.26.4 |
| UNKNOWN | CVE-2026-42507 | stdlib | bumped Go 1.26.3 → 1.26.4 |

Related to tetrateio/tetrate#30698
Related to tetrateio/tetrate#30699
Related to tetrateio/tetrate#30700
Related to tetrateio/tetrate#30701
Related to tetrateio/tetrate#30702
Related to tetrateio/tetrate#30703
Related to tetrateio/tetrate#30704
Related to tetrateio/tetrate#30705
Related to tetrateio/tetrate#30706
Related to tetrateio/tetrate#30707
Related to tetrateio/tetrate#30708
Related to tetrateio/tetrate#30709